### PR TITLE
fix: get version from tf module json

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,10 @@
 locals {
-  version           = "0.1.0" #TODO: Dynamically inject?
+  module_name = "fullstory-cloud-relay/aws"
+
+  version           = try(compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.module_name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0], "unreleased")
   create_dns_record = tobool(var.cloud_dns_zone_name != null)
   name              = "fullstory-relay"
-  endpoints         = {
+  endpoints = {
     edge : "edge.${var.target_fqdn}",
     rs : "rs.${var.target_fqdn}",
     services : "services.fullstory.com"
@@ -66,7 +68,7 @@ resource "google_dns_record_set" "fullstory_relay" {
   type         = "A"
   ttl          = 300
   managed_zone = data.google_dns_managed_zone.fullstory_relay[0].name
-  rrdatas      = [
+  rrdatas = [
     google_compute_global_address.fullstory_relay.address,
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  module_name = "fullstory-cloud-relay/aws"
+  module_name = "fullstory-cloud-relay/google"
 
   version           = try(compact([for m in jsondecode(file("${path.module}/../modules.json"))["Modules"] : length(regexall(".${local.module_name}.*", m["Source"])) > 0 ? m["Version"] : ""])[0], "unreleased")
   create_dns_record = tobool(var.cloud_dns_zone_name != null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Are these changes a new behavior? What was the old vs new -->
Dynamically inject module version from terraform init's downloaded modules.json file. That file looks somewhat like:
```
{"Modules":[{"Key":"fullstory_relay","Source":"registry.terraform.io/fullstorydev/fullstory-cloud-relay/google","Version":"0.1.0","Dir":".terraform/modules/fullstory_relay"},{"Key":"","Source":"","Dir":"."}]}
```

## Issue or Ticket
<!--- There should be an issue (github issue) or Jira ticket for this work -->

<!--- Please link to the issue here: -->
n/a


<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->


## Checklist before submitting PR for review
- [x] I have tested these changes with the included tfvars
- [ ] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [x] I have ensured my code is commented and any new terraform variables have proper descriptions
