### PR TITLE
fix: add missing datalayer path and add wildcard

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,11 @@ resource "google_compute_url_map" "fullstory_relay" {
     default_service = google_compute_backend_service.fullstory_relay["rs"].id
 
     path_rule {
-      paths   = ["/s/fs.js"]
+      paths   = ["/s/*"]
+      service = google_compute_backend_service.fullstory_relay["edge"].id
+    }
+    path_rule {
+      paths   = ["/datalayer/*"]
       service = google_compute_backend_service.fullstory_relay["edge"].id
     }
     path_rule {


### PR DESCRIPTION
## Description
- Adding new `/datalayer/*` path to go to edge backend
- Updating `/s/fs.js` to wildcard to match all


## Issue or Ticket
<!--- There should be an issue (github issue) or Jira ticket for this work -->

<!--- Please link to the issue here: -->


<!-- Comment this out if you'd like to include more information for an easier review
## Additional Info
 -->


## Checklist before submitting PR for review
- [ ] I have tested these changes with the included tfvars
- [ ] This change requires a doc update, and I've included it
- [x] My code follows the style guidelines of this project
- [ ] I have ensured my code is commented and any new terraform variables have proper descriptions
